### PR TITLE
Add support for uploading party finder data to multiple remotes

### DIFF
--- a/csharp/RemotePartyFinder/ConfigWindow.cs
+++ b/csharp/RemotePartyFinder/ConfigWindow.cs
@@ -10,165 +10,201 @@ using ImGuiNET;
 
 namespace RemotePartyFinder;
 
-public class ConfigWindow : Window, IDisposable {
-    private Configuration Configuration;
-    private List<UploadUrl> uploadUrls = new();
-    private bool uploadUrlsChanged;
-    private string uploadUrlTempString = string.Empty;
-    private string uploadUrlError = string.Empty;
+public class ConfigWindow : Window, IDisposable
+{
+    private readonly Configuration _configuration;
+    private List<UploadUrl> _uploadUrls;
+    private bool _uploadUrlsChanged;
+    private string _uploadUrlTempString = string.Empty;
+    private string _uploadUrlError = string.Empty;
 
-    public ConfigWindow(Plugin plugin) : base("Remote Party Finder") {
-        uploadUrlsChanged = false;
+    public ConfigWindow(Plugin plugin) : base("Remote Party Finder")
+    {
+        _uploadUrlsChanged = false;
         Flags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize;
         Size = new Vector2(500, 250);
-        Configuration = plugin.Configuration;
+        _configuration = plugin.Configuration;
 
-        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+        _uploadUrls = _configuration.UploadUrls.ToList();
     }
 
-    public void Dispose() { }
-
-    public override void OnClose() {
-        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+    public void Dispose()
+    {
     }
 
-    public void Save() {
-        Configuration.UploadUrls = uploadUrls.Select(x => x.Clone()).ToList();
-        if (uploadUrlsChanged) {
-            Configuration.Save();
-            uploadUrlsChanged = false;
+    public override void OnClose()
+    {
+        _uploadUrls = _configuration.UploadUrls.ToList();
+    }
+
+    private void Save()
+    {
+        _configuration.UploadUrls = _uploadUrls.ToList();
+        if (_uploadUrlsChanged)
+        {
+            _configuration.Save();
+            _uploadUrlsChanged = false;
         }
+
         Toggle();
     }
 
-    public override void Draw() {
-        var isAdvanced = Configuration.AdvancedSettingsEnabled;
-        ImGui.TextWrapped("This section is for advanced users to configure which services to send party finder data to. Only enable if you know what you are doing.");
-        if (ImGui.Checkbox("Enable Advanced Settings", ref isAdvanced)) {
-            Configuration.AdvancedSettingsEnabled = isAdvanced;
-            Configuration.Save();
+    public override void Draw()
+    {
+        var isAdvanced = _configuration.AdvancedSettingsEnabled;
+        ImGui.TextWrapped(
+            "This section is for advanced users to configure which services to send party finder data to. Only enable if you know what you are doing.");
+        if (ImGui.Checkbox("Enable Advanced Settings", ref isAdvanced))
+        {
+            _configuration.AdvancedSettingsEnabled = isAdvanced;
+            _configuration.Save();
         }
 
-        if (isAdvanced) {
-            using var id = ImRaii.PushId("uploadUrls");
-            ImGui.Columns(4);
+        if (!isAdvanced) return;
+        
+        using var id = ImRaii.PushId("uploadUrls");
+        ImGui.Columns(4);
 
-            ImGui.SetColumnWidth(0, 28 * ImGui.GetIO().FontGlobalScale);
-            ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X - (28 + 60 + 75) * ImGui.GetIO().FontGlobalScale);
-            ImGui.SetColumnWidth(2, 60 * ImGui.GetIO().FontGlobalScale);
-            ImGui.SetColumnWidth(3, 75 * ImGui.GetIO().FontGlobalScale);
+        ImGui.SetColumnWidth(0, 28 * ImGui.GetIO().FontGlobalScale);
+        ImGui.SetColumnWidth(1,
+            ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X -
+            (28 + 60 + 75) * ImGui.GetIO().FontGlobalScale);
+        ImGui.SetColumnWidth(2, 60 * ImGui.GetIO().FontGlobalScale);
+        ImGui.SetColumnWidth(3, 75 * ImGui.GetIO().FontGlobalScale);
 
-            ImGui.Separator();
+        ImGui.Separator();
 
-            ImGui.TextUnformatted("#");
+        ImGui.TextUnformatted("#");
 
-            ImGui.NextColumn();
-            ImGui.TextUnformatted("URL");
+        ImGui.NextColumn();
+        ImGui.TextUnformatted("URL");
 
-            ImGui.NextColumn();
-            ImGui.TextUnformatted("Enabled");
+        ImGui.NextColumn();
+        ImGui.TextUnformatted("Enabled");
 
-            ImGui.NextColumn();
-            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - ImGui.CalcTextSize("Add/Delete").X) / 2 - 2);
-            ImGui.TextUnformatted("Add/Delete");
+        ImGui.NextColumn();
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() +
+            (ImGui.GetColumnWidth() - ImGui.CalcTextSize("Add/Delete").X) / 2 - 2);
+        ImGui.TextUnformatted("Add/Delete");
 
-            ImGui.NextColumn();
-            ImGui.Separator();
+        ImGui.NextColumn();
+        ImGui.Separator();
+        
+        UploadUrl? uploadUrlToRemove = null;
 
-            UploadUrl uploadUrlToRemove = null;
+        var urlNumber = 1;
 
-            var urlNumber = 1;
+        foreach (var uploadUrl in _uploadUrls)
+        {
+            var isEnabled = uploadUrl.IsEnabled;
+            var isDefault = uploadUrl.IsDefault;
 
-            foreach (var uploadUrl in uploadUrls) {
-                var isEnabled = uploadUrl.IsEnabled;
-                var isDefault = uploadUrl.IsDefault;
-
-                id.Push(uploadUrl.Url);
-                ImGui.TextUnformatted(urlNumber.ToString());
-
-                ImGui.NextColumn();
-                ImGui.TextUnformatted(uploadUrl.Url);
-
-                ImGui.NextColumn();
-                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 6 - (12 * ImGui.GetIO().FontGlobalScale));
-
-                if (ImGui.Checkbox("##uploadUrlCheckbox", ref isEnabled)) {
-                    this.uploadUrlsChanged = true;
-                }
-
-                ImGui.NextColumn();
-                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
-
-                if (!uploadUrl.IsDefault && ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash)) {
-                    uploadUrlToRemove = uploadUrl;
-                }
-
-                uploadUrl.IsEnabled = isEnabled;
-                urlNumber++;
-                id.Pop();
-
-                ImGui.NextColumn();
-                ImGui.Separator();
-            }
-
-            if (uploadUrlToRemove != null) {
-                this.uploadUrls.Remove(uploadUrlToRemove);
-                this.uploadUrlsChanged = true;
-            }
-
+            id.Push(uploadUrl.Url);
             ImGui.TextUnformatted(urlNumber.ToString());
 
             ImGui.NextColumn();
-            ImGui.SetNextItemWidth(-1);
-            ImGui.InputText("##uploadUrlInput", ref uploadUrlTempString, 300);
-            ImGui.NextColumn();
+            ImGui.TextUnformatted(uploadUrl.Url);
 
             ImGui.NextColumn();
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 6 -
+                                (12 * ImGui.GetIO().FontGlobalScale));
 
-            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
-            if (!string.IsNullOrEmpty(uploadUrlTempString) && ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Plus)) {
-                uploadUrlTempString = uploadUrlTempString.TrimEnd();
-
-                if (uploadUrls.Any(r => string.Equals(r.Url, uploadUrlTempString, StringComparison.InvariantCultureIgnoreCase))) {
-                    uploadUrlError = "Endpoint already exists.";
-                    Task.Delay(5000).ContinueWith(t => uploadUrlError = string.Empty);
-                } else if (!ValidUrl(uploadUrlTempString)) {
-                    this.uploadUrlError = "Invalid URL format.";
-                    Task.Delay(5000).ContinueWith(t => uploadUrlError = string.Empty);
-                } else {
-                    uploadUrls.Add(new UploadUrl(uploadUrlTempString));
-                    uploadUrlsChanged = true;
-                    uploadUrlTempString = string.Empty;
-                }
+            if (ImGui.Checkbox("##uploadUrlCheckbox", ref isEnabled))
+            {
+                this._uploadUrlsChanged = true;
             }
 
             ImGui.NextColumn();
-            ImGui.Separator();
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() +
+                                (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
 
-            ImGui.Columns(1);
-            if (!string.IsNullOrEmpty(uploadUrlError)) {
-                ImGui.TextColored(new Vector4(1, 0, 0, 1), uploadUrlError);
-            } else {
-                if (ImGui.Button("Save Changes##uploadUrlSave")) {
-                    Save();
-                }
-                ImGui.SameLine();
-                if (ImGui.Button("Reset To Default##uploadUrlDefault")) {
-                    ResetToDefault();
-                }
+            if (!uploadUrl.IsDefault && ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash))
+            {
+                uploadUrlToRemove = uploadUrl;
+            }
+
+            uploadUrl.IsEnabled = isEnabled;
+            urlNumber++;
+            id.Pop();
+
+            ImGui.NextColumn();
+            ImGui.Separator();
+        }
+
+        if (uploadUrlToRemove != null)
+        {
+            this._uploadUrls.Remove(uploadUrlToRemove);
+            this._uploadUrlsChanged = true;
+        }
+
+        ImGui.TextUnformatted(urlNumber.ToString());
+
+        ImGui.NextColumn();
+        ImGui.SetNextItemWidth(-1);
+        ImGui.InputText("##uploadUrlInput", ref _uploadUrlTempString, 300);
+        ImGui.NextColumn();
+
+        ImGui.NextColumn();
+
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() +
+                            (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
+        if (!string.IsNullOrEmpty(_uploadUrlTempString) &&
+            ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Plus))
+        {
+            _uploadUrlTempString = _uploadUrlTempString.TrimEnd();
+
+            if (_uploadUrls.Any(r =>
+                    string.Equals(r.Url, _uploadUrlTempString, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                _uploadUrlError = "Endpoint already exists.";
+                Task.Delay(5000).ContinueWith(t => _uploadUrlError = string.Empty);
+            }
+            else if (!ValidUrl(_uploadUrlTempString))
+            {
+                this._uploadUrlError = "Invalid URL format.";
+                Task.Delay(5000).ContinueWith(t => _uploadUrlError = string.Empty);
+            }
+            else
+            {
+                _uploadUrls.Add(new UploadUrl(_uploadUrlTempString));
+                _uploadUrlsChanged = true;
+                _uploadUrlTempString = string.Empty;
+            }
+        }
+
+        ImGui.NextColumn();
+        ImGui.Separator();
+
+        ImGui.Columns(1);
+        if (!string.IsNullOrEmpty(_uploadUrlError))
+        {
+            ImGui.TextColored(new Vector4(1, 0, 0, 1), _uploadUrlError);
+        }
+        else
+        {
+            if (ImGui.Button("Save Changes##uploadUrlSave"))
+            {
+                Save();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Reset To Default##uploadUrlDefault"))
+            {
+                ResetToDefault();
             }
         }
     }
 
-    private void ResetToDefault() {
-        Configuration.UploadUrls.Clear();
-        Configuration.Initialize();
-        Configuration.Save();
-        uploadUrlsChanged = false;
-        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+    private void ResetToDefault()
+    {
+        _configuration.UploadUrls.Clear();
+        _configuration.Initialize();
+        _configuration.Save();
+        _uploadUrlsChanged = false;
+        _uploadUrls = _configuration.UploadUrls.ToList();
     }
 
     private static bool ValidUrl(string url)
-    => Uri.TryCreate(url, UriKind.Absolute, out var uriResult)
-    && (uriResult.Scheme == Uri.UriSchemeHttps || uriResult.Scheme == Uri.UriSchemeHttp);
+        => Uri.TryCreate(url, UriKind.Absolute, out var uriResult)
+           && (uriResult.Scheme == Uri.UriSchemeHttps || uriResult.Scheme == Uri.UriSchemeHttp);
 }

--- a/csharp/RemotePartyFinder/ConfigWindow.cs
+++ b/csharp/RemotePartyFinder/ConfigWindow.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Dalamud.Interface.Components;
+using Dalamud.Interface.Utility.Raii;
+using Dalamud.Interface.Windowing;
+using ImGuiNET;
+
+namespace RemotePartyFinder;
+
+public class ConfigWindow : Window, IDisposable {
+    private Configuration Configuration;
+    private List<UploadUrl> uploadUrls = new();
+    private bool uploadUrlsChanged;
+    private string uploadUrlTempString = string.Empty;
+    private string uploadUrlError = string.Empty;
+    public ConfigWindow(Plugin plugin) : base("Remote Party Finder###Title") {
+        uploadUrlsChanged = false;
+        Flags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize;
+        Size = new Vector2(500, 250);
+        Configuration = plugin.Configuration;
+
+        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+    }
+
+    public void Dispose() {}
+
+    public override void OnClose() {
+        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+    }
+
+    public void Save() {
+        Configuration.UploadUrls = uploadUrls.Select(x => x.Clone()).ToList();
+        if (uploadUrlsChanged) {
+            Configuration.Save();
+            uploadUrlsChanged = false;
+        }
+        Toggle();
+    }
+
+    public override void Draw() {
+        var isAdvanced = Configuration.AdvancedSettingsEnabled;
+        ImGui.TextWrapped("This section is for advanced users to configure which services to send party finder data to. Only enable if you know what you are doing.");
+        if (ImGui.Checkbox("Enable Advanced Settings", ref isAdvanced)) {
+            Configuration.AdvancedSettingsEnabled = isAdvanced;
+            Configuration.Save();
+        }
+
+        if (isAdvanced) {
+            using var id = ImRaii.PushId("uploadUrls");
+            ImGui.Columns(4);
+
+            ImGui.SetColumnWidth(0, 28 * ImGui.GetIO().FontGlobalScale);
+            ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X - (28 + 60 + 75) * ImGui.GetIO().FontGlobalScale);
+            ImGui.SetColumnWidth(2, 60 * ImGui.GetIO().FontGlobalScale);
+            ImGui.SetColumnWidth(3, 75 * ImGui.GetIO().FontGlobalScale);
+
+            ImGui.Separator();
+
+            ImGui.TextUnformatted("#");
+
+            ImGui.NextColumn();
+            ImGui.TextUnformatted("URL");
+
+            ImGui.NextColumn();
+            ImGui.TextUnformatted("Enabled");
+
+            ImGui.NextColumn();
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - ImGui.CalcTextSize("Add/Delete").X) / 2 - 2);
+            ImGui.TextUnformatted("Add/Delete");
+
+            ImGui.NextColumn();
+            ImGui.Separator();
+
+
+            UploadUrl uploadUrlToRemove = null;
+
+            var urlNumber = 1;
+
+            foreach (var uploadUrl in uploadUrls) {
+                var isEnabled = uploadUrl.IsEnabled;
+                var isDefault = uploadUrl.IsDefault;
+
+                id.Push(uploadUrl.Url);
+                ImGui.TextUnformatted(urlNumber.ToString());
+
+                ImGui.NextColumn();
+                ImGui.TextUnformatted(uploadUrl.Url);
+
+                ImGui.NextColumn();
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 6 - (12 * ImGui.GetIO().FontGlobalScale));
+
+                if (ImGui.Checkbox("##uploadUrlCheckbox", ref isEnabled)) {
+                    this.uploadUrlsChanged = true;
+                }
+
+                ImGui.NextColumn();
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
+
+                if (!uploadUrl.IsDefault && ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash)) {
+                    uploadUrlToRemove = uploadUrl;
+                }
+
+                uploadUrl.IsEnabled = isEnabled;
+                urlNumber++;
+                id.Pop();
+
+                ImGui.NextColumn();
+                ImGui.Separator();
+            }
+
+            if (uploadUrlToRemove != null) {
+                this.uploadUrls.Remove(uploadUrlToRemove);
+                this.uploadUrlsChanged = true;
+            }
+
+            ImGui.TextUnformatted(urlNumber.ToString());
+
+            ImGui.NextColumn();
+            ImGui.SetNextItemWidth(-1);
+            ImGui.InputText("##uploadUrlInput", ref uploadUrlTempString, 300);
+            ImGui.NextColumn();
+
+            ImGui.NextColumn();
+
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() - (24 * ImGui.GetIO().FontGlobalScale)) / 2);
+            if (!string.IsNullOrEmpty(uploadUrlTempString) && ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Plus)) {
+                uploadUrlTempString = uploadUrlTempString.TrimEnd();
+
+                if (uploadUrls.Any(r => string.Equals(r.Url, uploadUrlTempString, StringComparison.InvariantCultureIgnoreCase))) {
+                    uploadUrlError = "Endpoint already exists.";
+                    Task.Delay(5000).ContinueWith(t => uploadUrlError = string.Empty);
+                } else if (!ValidUrl(uploadUrlTempString)) {
+                    this.uploadUrlError = "Invalid URL format.";
+                    Task.Delay(5000).ContinueWith(t => uploadUrlError = string.Empty);
+                } else {
+                    uploadUrls.Add(new UploadUrl(uploadUrlTempString));
+                    uploadUrlsChanged = true;
+                    uploadUrlTempString = string.Empty;
+                }
+            }
+
+            ImGui.NextColumn();
+            ImGui.Separator();
+
+            ImGui.Columns(1);
+            if (!string.IsNullOrEmpty(uploadUrlError)) {
+                ImGui.TextColored(new Vector4(1, 0, 0, 1), uploadUrlError);
+            } else {
+                if (ImGui.Button("Save Changes##uploadUrlSave")) {
+                    Save();
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Reset To Default##uploadUrlDefault")) {
+                    ResetToDefault();
+                }
+            }
+        }
+    }
+
+    private void ResetToDefault() {
+        Configuration.UploadUrls.Clear();
+        Configuration.Initialize();
+        Configuration.Save();
+        uploadUrlsChanged = false;
+        uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
+    }
+
+    private static bool ValidUrl(string url)
+    => Uri.TryCreate(url, UriKind.Absolute, out var uriResult)
+    && (uriResult.Scheme == Uri.UriSchemeHttps || uriResult.Scheme == Uri.UriSchemeHttp);
+}

--- a/csharp/RemotePartyFinder/ConfigWindow.cs
+++ b/csharp/RemotePartyFinder/ConfigWindow.cs
@@ -47,6 +47,7 @@ public class ConfigWindow : Window, IDisposable
 
         if (!isAdvanced) return;
 
+        
         using (ImRaii.Table("uploadUrls", 3, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
         {
             ImGui.TableSetupColumn("#", ImGuiTableColumnFlags.WidthFixed);
@@ -54,8 +55,11 @@ public class ConfigWindow : Window, IDisposable
             ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed);
             ImGui.TableHeadersRow();
             
+            using var id = ImRaii.PushId("urls");
             foreach (var (uploadUrl, index) in _configuration.UploadUrls.Select((url, index) => (url, index + 1)))
             {
+                id.Push(index);
+
                 ImGui.TableNextRow();
                 ImGui.TableSetColumnIndex(0);
                 ImGui.TextUnformatted(index.ToString());
@@ -70,13 +74,16 @@ public class ConfigWindow : Window, IDisposable
                     uploadUrl.IsEnabled = isEnabled;
                 }
 
-                if (uploadUrl.IsDefault) continue;
-                
-                ImGui.SameLine();
-                if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash))
+                if (!uploadUrl.IsDefault)
                 {
-                    _configuration.UploadUrls = _configuration.UploadUrls.Remove(uploadUrl);
+                    ImGui.SameLine();
+                    if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash))
+                    {
+                        _configuration.UploadUrls = _configuration.UploadUrls.Remove(uploadUrl);
+                    }
                 }
+                
+                id.Pop();
             }
             
             ImGui.TableNextRow();

--- a/csharp/RemotePartyFinder/ConfigWindow.cs
+++ b/csharp/RemotePartyFinder/ConfigWindow.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Reflection;
 using System.Threading.Tasks;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
@@ -17,7 +16,8 @@ public class ConfigWindow : Window, IDisposable {
     private bool uploadUrlsChanged;
     private string uploadUrlTempString = string.Empty;
     private string uploadUrlError = string.Empty;
-    public ConfigWindow(Plugin plugin) : base("Remote Party Finder###Title") {
+
+    public ConfigWindow(Plugin plugin) : base("Remote Party Finder") {
         uploadUrlsChanged = false;
         Flags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize;
         Size = new Vector2(500, 250);
@@ -26,7 +26,7 @@ public class ConfigWindow : Window, IDisposable {
         uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
     }
 
-    public void Dispose() {}
+    public void Dispose() { }
 
     public override void OnClose() {
         uploadUrls = Configuration.UploadUrls.Select(x => x.Clone()).ToList();
@@ -74,7 +74,6 @@ public class ConfigWindow : Window, IDisposable {
 
             ImGui.NextColumn();
             ImGui.Separator();
-
 
             UploadUrl uploadUrlToRemove = null;
 

--- a/csharp/RemotePartyFinder/Configuration.cs
+++ b/csharp/RemotePartyFinder/Configuration.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Dalamud.Configuration;
 
 namespace RemotePartyFinder;
@@ -8,15 +8,12 @@ namespace RemotePartyFinder;
 public class Configuration : IPluginConfiguration {
     public int Version { get; set; } = 1;
     public bool AdvancedSettingsEnabled = false;
-    public List<UploadUrl> UploadUrls = [];
+    public ImmutableList<UploadUrl> UploadUrls = DefaultUploadUrls();
 
-    public void Initialize()
-    {
-        if (UploadUrls.Count != 0) return;
-        
-        UploadUrls.Add(new UploadUrl("https://xivpf.com/contribute/multiple") { IsDefault = true });
-        UploadUrls.Add(new UploadUrl("https://findingway.io/receiver") { IsDefault = true });
-    }
+    public static ImmutableList<UploadUrl> DefaultUploadUrls() => [
+        new("https://xivpf.com/contribute/multiple") { IsDefault = true },
+        new("https://findingway.io/receiver") { IsDefault = true }
+    ];
 
     public void Save() {
         Plugin.PluginInterface.SavePluginConfig(this);

--- a/csharp/RemotePartyFinder/Configuration.cs
+++ b/csharp/RemotePartyFinder/Configuration.cs
@@ -8,13 +8,14 @@ namespace RemotePartyFinder;
 public class Configuration : IPluginConfiguration {
     public int Version { get; set; } = 1;
     public bool AdvancedSettingsEnabled = false;
-    public List<UploadUrl> UploadUrls = new();
+    public List<UploadUrl> UploadUrls = [];
 
-    public void Initialize() {
-        if (UploadUrls.Count == 0) {
-            UploadUrls.Add(new UploadUrl("https://xivpf.com/contribute/multiple") { IsDefault = true });
-            UploadUrls.Add(new UploadUrl("https://findingway.io/receiver") { IsDefault = true });
-        }
+    public void Initialize()
+    {
+        if (UploadUrls.Count != 0) return;
+        
+        UploadUrls.Add(new UploadUrl("https://xivpf.com/contribute/multiple") { IsDefault = true });
+        UploadUrls.Add(new UploadUrl("https://findingway.io/receiver") { IsDefault = true });
     }
 
     public void Save() {

--- a/csharp/RemotePartyFinder/Configuration.cs
+++ b/csharp/RemotePartyFinder/Configuration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Dalamud.Configuration;
-using Dalamud.Plugin;
 
 namespace RemotePartyFinder;
 
@@ -16,7 +15,6 @@ public class Configuration : IPluginConfiguration {
             UploadUrls.Add(new UploadUrl("https://xivpf.com/contribute/multiple") { IsDefault = true });
             UploadUrls.Add(new UploadUrl("https://findingway.io/receiver") { IsDefault = true });
         }
-
     }
 
     public void Save() {

--- a/csharp/RemotePartyFinder/Configuration.cs
+++ b/csharp/RemotePartyFinder/Configuration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Dalamud.Configuration;
+using Dalamud.Plugin;
+
+namespace RemotePartyFinder;
+
+[Serializable]
+public class Configuration : IPluginConfiguration {
+    public int Version { get; set; } = 1;
+    public bool AdvancedSettingsEnabled = false;
+    public List<UploadUrl> UploadUrls = new();
+
+    public void Initialize() {
+        if (UploadUrls.Count == 0) {
+            UploadUrls.Add(new UploadUrl("https://xivpf.com/contribute/multiple") { IsDefault = true });
+            UploadUrls.Add(new UploadUrl("https://findingway.io/receiver") { IsDefault = true });
+        }
+
+    }
+
+    public void Save() {
+        Plugin.PluginInterface.SavePluginConfig(this);
+    }
+}

--- a/csharp/RemotePartyFinder/Gatherer.cs
+++ b/csharp/RemotePartyFinder/Gatherer.cs
@@ -47,7 +47,6 @@ internal class Gatherer : IDisposable {
         }
 
         this.UploadTimer.Restart();
-        List<UploadUrl> uploadUrls = Plugin.Configuration.UploadUrls.Select(x => x.Clone()).ToList();
 
         foreach (var (batch, listings) in this.Batches.ToList()) {
             this.Batches.Remove(batch, out _);
@@ -57,9 +56,8 @@ internal class Gatherer : IDisposable {
                     .ToList();
                 var json = JsonConvert.SerializeObject(uploadable);
 
-                foreach (var uploadUrl in uploadUrls) {
-                    if (!uploadUrl.IsEnabled) continue;
-
+                foreach (var uploadUrl in Plugin.Configuration.UploadUrls.Where(uploadUrl => uploadUrl.IsEnabled))
+                {
                     var resp = await this.Client.PostAsync(uploadUrl.Url, new StringContent(json) {
                         Headers = { ContentType = MediaTypeHeaderValue.Parse("application/json") },
                     });

--- a/csharp/RemotePartyFinder/Plugin.cs
+++ b/csharp/RemotePartyFinder/Plugin.cs
@@ -25,7 +25,6 @@ public class Plugin : IDalamudPlugin {
 
     public Plugin() {
         Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
-        Configuration.Initialize();
         this.Gatherer = new Gatherer(this);
         ConfigWindow = new ConfigWindow(this);
         WindowSystem.AddWindow(ConfigWindow);

--- a/csharp/RemotePartyFinder/RemotePartyFinder.csproj
+++ b/csharp/RemotePartyFinder/RemotePartyFinder.csproj
@@ -34,14 +34,14 @@
             <HintPath>$(DalamudLibPath)\Lumina.Excel.dll</HintPath>
             <Private>false</Private>
         </Reference>
-      <Reference Include="Newtonsoft.Json">
-        <HintPath>$(DalamudLibPath)\Newtonsoft.Json.dll</HintPath>
-        <Private>false</Private>
-      </Reference>
-      <Reference Include="ImGuiNET">
-        <HintPath>$(DalamudLibPath)\ImGui.NET.dll</HintPath>
-        <Private>false</Private>
-      </Reference>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>$(DalamudLibPath)\Newtonsoft.Json.dll</HintPath>
+          <Private>false</Private>
+        </Reference>
+        <Reference Include="ImGuiNET">
+          <HintPath>$(DalamudLibPath)\ImGui.NET.dll</HintPath>
+          <Private>false</Private>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup>

--- a/csharp/RemotePartyFinder/RemotePartyFinder.csproj
+++ b/csharp/RemotePartyFinder/RemotePartyFinder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Version>1.0.14</Version>
@@ -34,10 +34,14 @@
             <HintPath>$(DalamudLibPath)\Lumina.Excel.dll</HintPath>
             <Private>false</Private>
         </Reference>
-        <Reference Include="Newtonsoft.Json">
-            <HintPath>$(DalamudLibPath)\Newtonsoft.Json.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
+      <Reference Include="Newtonsoft.Json">
+        <HintPath>$(DalamudLibPath)\Newtonsoft.Json.dll</HintPath>
+        <Private>false</Private>
+      </Reference>
+      <Reference Include="ImGuiNET">
+        <HintPath>$(DalamudLibPath)\ImGui.NET.dll</HintPath>
+        <Private>false</Private>
+      </Reference>
     </ItemGroup>
 
     <ItemGroup>

--- a/csharp/RemotePartyFinder/UploadUrl.cs
+++ b/csharp/RemotePartyFinder/UploadUrl.cs
@@ -1,15 +1,8 @@
 ﻿namespace RemotePartyFinder;
 
-public class UploadUrl {
-    public string Url { get; set; }
-    public bool IsDefault { get; set; }
-    public bool IsEnabled { get; set; }
-
-    public UploadUrl(string url) {
-        Url = url;
-        IsDefault = false;
-        IsEnabled = true;
-    }
-
-    public UploadUrl Clone() => this.MemberwiseClone() as UploadUrl;
+public record UploadUrl(string Url)
+{
+    public string Url { get; set; } = Url;
+    public bool IsDefault { get; init; }
+    public bool IsEnabled { get; set; } = true;
 }

--- a/csharp/RemotePartyFinder/UploadUrl.cs
+++ b/csharp/RemotePartyFinder/UploadUrl.cs
@@ -1,0 +1,15 @@
+﻿namespace RemotePartyFinder;
+
+public class UploadUrl {
+    public string Url { get; set; }
+    public bool IsDefault { get; set; }
+    public bool IsEnabled { get; set; }
+
+    public UploadUrl(string url) {
+        Url = url;
+        IsDefault = false;
+        IsEnabled = true;
+    }
+
+    public UploadUrl Clone() => this.MemberwiseClone() as UploadUrl;
+}

--- a/csharp/RemotePartyFinder/UploadableListing.cs
+++ b/csharp/RemotePartyFinder/UploadableListing.cs
@@ -5,7 +5,7 @@ using Dalamud.Game.Gui.PartyFinder.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace RemotePartyFinder; 
+namespace RemotePartyFinder;
 
 [Serializable]
 [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
@@ -36,12 +36,12 @@ internal class UploadableListing {
 
     internal UploadableListing(IPartyFinderListing listing) {
         this.Id = listing.Id;
-        this.ContentIdLower = (uint) listing.ContentId;
+        this.ContentIdLower = (uint)listing.ContentId;
         this.Name = listing.Name.Encode();
         this.Description = listing.Description.Encode();
-        this.CreatedWorld = (ushort) listing.World.Value.RowId;
-        this.HomeWorld = (ushort) listing.HomeWorld.Value.RowId;
-        this.CurrentWorld = (ushort) listing.CurrentWorld.Value.RowId;
+        this.CreatedWorld = (ushort)listing.World.Value.RowId;
+        this.HomeWorld = (ushort)listing.HomeWorld.Value.RowId;
+        this.CurrentWorld = (ushort)listing.CurrentWorld.Value.RowId;
         this.Category = listing.Category;
         this.Duty = listing.RawDuty;
         this.DutyType = listing.DutyType;
@@ -67,6 +67,6 @@ internal class UploadableSlot {
     public uint Accepting { get; } // TODO: JobFlags should : uint
 
     internal UploadableSlot(PartyFinderSlot slot) {
-        this.Accepting = slot.Accepting.Aggregate((uint) 0, (agg, flag) => agg | (uint)flag);
+        this.Accepting = slot.Accepting.Aggregate((uint)0, (agg, flag) => agg | (uint)flag);
     }
 }

--- a/csharp/RemotePartyFinder/packages.lock.json
+++ b/csharp/RemotePartyFinder/packages.lock.json
@@ -7,6 +7,40 @@
         "requested": "[11.0.0, )",
         "resolved": "11.0.0",
         "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
+      },
+      "Lumina": {
+        "type": "Transitive",
+        "resolved": "5.4.0",
+        "contentHash": "WRAxXQ7PZDJSjnM9hP2NI7oI8ro8B6brju6Qy4A7TW935mhSf9sXhK9O1Dr4nbCj5YPp7s7kveocsGqP6nus5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.7"
+        }
+      },
+      "Lumina.Excel": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "6FLmGfQXDVKUoDjG83df9Mmcq0cRez1bqXaLiByY+rp6x3MoQjvuSpr2p3DF4Hte+L6iDXCYTjwQM2DoQfBXMg==",
+        "dependencies": {
+          "Lumina": "5.4.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.7",
+        "contentHash": "2yLweyqmpuuFSRo+I3sLHMxmnAgNcI537kBJiyv49U2ZEqo00jZcG8lrnD8uCiOJp9IklYyTZULtbsXoFVzsjQ=="
+      },
+      "Pidgin": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "Jl7OaTEcyMxh4bCLTyh8Tnk0Efwd4hIYvszaLkFhU6oDIa7rdZF1s9f1MAvC4xyevzGwR8ZmVTQwoDyih6/66A=="
+      },
+      "sourcegenerator": {
+        "type": "Project",
+        "dependencies": {
+          "Lumina": "[5.4.0, )",
+          "Lumina.Excel": "[7.1.2, )",
+          "Pidgin": "[3.2.1, )"
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds support for uploading party finder data to different endpoints. The default endpoints that are included cannot be removed from the list under normal conditions but can be disabled (to prevent people from accidentally shooting themselves in the foot). Any endpoints that are added can be disabled and/or removed. Currently, the default endpoints are xivpf and Findingway. 

Let me know if you'd like any changes!
## Config window preview
![image](https://github.com/user-attachments/assets/44a0ed40-24a2-46fe-8710-cb731280c34f)
![image](https://github.com/user-attachments/assets/312df678-af07-4547-a6a5-25d29d70c584)
