### PR TITLE
Add ability to filter listings based on jobs

### DIFF
--- a/server/assets/listings.css
+++ b/server/assets/listings.css
@@ -8,6 +8,7 @@
 }
 
 .filter-controls .control {
+    display: flex;
     width: max-content;
     flex: 0 1 auto;
     margin-left: 1em;
@@ -19,8 +20,55 @@
 }
 
 .filter-controls .control > label > * {
-    flex: 0 1 auto;
+    flex: 1 1 auto;
+    margin-bottom: 0;
     margin-top: .5em;
+}
+
+.filter-controls .roles {
+    width: max-content;
+    flex: 0 1 auto;
+    margin-left: 1em;
+}
+
+.filter-controls .roles > div > input[type=checkbox] {
+    display: none;
+}
+
+.filter-controls .roles > div > label {
+    width: 2em;
+    height: 2em;
+    opacity: 50%;
+    margin-right: 0;
+    border: 1px solid currentColor;
+}
+
+.filter-controls .roles > div > label.healer {
+    background-color: var(--healer-green);
+}
+
+.filter-controls .roles > div > label.tank {
+    background-color: var(--tank-blue);
+}
+
+.filter-controls .roles > div > label.dps {
+    background-color: var(--dps-red);
+}
+
+.filter-controls .roles > div > label:hover {
+    opacity: 75%;
+}
+
+.filter-controls .roles > div > input[type=checkbox]:checked + label {
+    border: 1px solid currentColor;
+    opacity: 100%;
+}
+
+.filter-controls .roles > div > label > svg  {
+    width: 100%;
+    height: 100%;
+    fill: var(--icon-gold);
+    opacity: 100%;
 }
 
 .js #listings {
@@ -233,5 +281,9 @@
 
     #listings > .listing .meta > .item .text {
         order: 2;
+    }
+
+    .filter-controls .roles > div > label:hover {
+        opacity: 50%;
     }
 }

--- a/server/assets/listings.js
+++ b/server/assets/listings.js
@@ -118,6 +118,10 @@
         }
 
         function roleFilter(item) {
+            // Do not filter alliance raid / pvp because the jobs present are not accurate
+            if (Number(item.elm.dataset.numParties) !== 1) {
+                return true;
+            }
             return state.roles === 0n || state.roles & BigInt(item.elm.dataset.joinableRoles);
         }
 

--- a/server/assets/listings.js
+++ b/server/assets/listings.js
@@ -4,6 +4,7 @@
     const state = {
         allowed: [],
         centre: 'All',
+        roles: 0n,
         list: null,
         lang: null,
     };
@@ -61,6 +62,8 @@
         let dataCentre = document.getElementById('data-centre-filter');
         dataCentre.value = state.centre;
 
+        state.roles = 0n;
+
         let language = document.getElementById('language');
         if (state.lang === null) {
             state.lang = language.dataset.accept;
@@ -97,7 +100,11 @@
             return state.centre === "All" || state.centre === item.values().centre;
         }
 
-        state.list.filter(item => dataCentreFilter(item) && categoryFilter(item));
+        function roleFilter(item) {
+            return state.roles === 0n || state.roles & BigInt(item.elm.dataset.joinableRoles);
+        }
+
+        state.list.filter(item => dataCentreFilter(item) && categoryFilter(item) && roleFilter(item));
     }
 
     function setUpDataCentreFilter() {
@@ -155,11 +162,26 @@
         });
     }
 
+    function setUpRoleFilter() {
+        let select = document.getElementById('role-filter');
+
+        select.addEventListener('change', (event) => {
+            let value = BigInt(event.target.value);
+            if (event.target.checked) {
+                state.roles |= value;
+            } else {
+                state.roles &= ~value;
+            }
+            refilter();
+        });
+    }
+
     addJsClass();
     saveLoadState();
     reflectState();
     state.list = setUpList();
     setUpDataCentreFilter();
     setUpCategoryFilter();
+    setUpRoleFilter();
     refilter();
 })();

--- a/server/src/ffxiv/jobs.rs
+++ b/server/src/ffxiv/jobs.rs
@@ -1,3 +1,4 @@
+use crate::listing::JobFlags;
 use ffxiv_types::jobs::{Class, ClassJob, Job, NonCombatJob};
 use std::collections::HashMap;
 
@@ -45,5 +46,39 @@ lazy_static::lazy_static! {
         40 => ClassJob::Job(Job::Sage),
         41 => ClassJob::Job(Job::Viper),
         42 => ClassJob::Job(Job::Pictomancer),
+    };
+
+    pub static ref JOBS_TO_FLAGS: HashMap<&'static str, JobFlags> = maplit::hashmap! {
+        ClassJob::Class(Class::Gladiator).as_str() => JobFlags::GLADIATOR,
+        ClassJob::Class(Class::Pugilist).as_str() => JobFlags::PUGILIST,
+        ClassJob::Class(Class::Marauder).as_str() => JobFlags::MARAUDER,
+        ClassJob::Class(Class::Lancer).as_str() => JobFlags::LANCER,
+        ClassJob::Class(Class::Archer).as_str() => JobFlags::ARCHER,
+        ClassJob::Class(Class::Conjurer).as_str() => JobFlags::CONJURER,
+        ClassJob::Class(Class::Thaumaturge).as_str() => JobFlags::THAUMATURGE,
+        ClassJob::Job(Job::Paladin).as_str() => JobFlags::PALADIN,
+        ClassJob::Job(Job::Monk).as_str() => JobFlags::MONK,
+        ClassJob::Job(Job::Warrior).as_str() => JobFlags::WARRIOR,
+        ClassJob::Job(Job::Dragoon).as_str() => JobFlags::DRAGOON,
+        ClassJob::Job(Job::Bard).as_str() => JobFlags::BARD,
+        ClassJob::Job(Job::WhiteMage).as_str() => JobFlags::WHITE_MAGE,
+        ClassJob::Job(Job::BlackMage).as_str() => JobFlags::BLACK_MAGE,
+        ClassJob::Class(Class::Arcanist).as_str() => JobFlags::ARCANIST,
+        ClassJob::Job(Job::Summoner).as_str() => JobFlags::SUMMONER,
+        ClassJob::Job(Job::Scholar).as_str() => JobFlags::SCHOLAR,
+        ClassJob::Class(Class::Rogue).as_str() => JobFlags::ROGUE,
+        ClassJob::Job(Job::Ninja).as_str() => JobFlags::NINJA,
+        ClassJob::Job(Job::Machinist).as_str() => JobFlags::MACHINIST,
+        ClassJob::Job(Job::DarkKnight).as_str() => JobFlags::DARK_KNIGHT,
+        ClassJob::Job(Job::Astrologian).as_str() => JobFlags::ASTROLOGIAN,
+        ClassJob::Job(Job::Samurai).as_str() => JobFlags::SAMURAI,
+        ClassJob::Job(Job::RedMage).as_str() => JobFlags::RED_MAGE,
+        ClassJob::Job(Job::BlueMage).as_str() => JobFlags::BLUE_MAGE,
+        ClassJob::Job(Job::Gunbreaker).as_str() => JobFlags::GUNBREAKER,
+        ClassJob::Job(Job::Dancer).as_str() => JobFlags::DANCER,
+        ClassJob::Job(Job::Reaper).as_str() => JobFlags::REAPER,
+        ClassJob::Job(Job::Sage).as_str() => JobFlags::SAGE,
+        ClassJob::Job(Job::Viper).as_str() => JobFlags::VIPER,
+        ClassJob::Job(Job::Pictomancer).as_str() => JobFlags::PICTOMANCER,
     };
 }

--- a/server/src/listing.rs
+++ b/server/src/listing.rs
@@ -568,10 +568,15 @@ impl JobFlags {
         classes.join(" ")
     }
 
-    pub fn get_all_jobs() -> Vec<(&'static str, Vec<JobFlags>)> {
+    pub fn get_all_jobs() -> Vec<(LocalisedText, Vec<JobFlags>)> {
         vec![
             (
-                "Tanks",
+                LocalisedText {
+                    en: "Tank",
+                    ja: "タンク",
+                    de: "Verteidiger",
+                    fr: "Tank",
+                },
                 vec![
                     Self::PALADIN,
                     Self::WARRIOR,
@@ -580,7 +585,12 @@ impl JobFlags {
                 ],
             ),
             (
-                "Healers",
+                LocalisedText {
+                    en: "Healer",
+                    ja: "ヒーラー",
+                    de: "Heiler",
+                    fr: "Soigneur",
+                },
                 vec![
                     Self::WHITE_MAGE,
                     Self::SCHOLAR,
@@ -589,7 +599,12 @@ impl JobFlags {
                 ],
             ),
             (
-                "Melees",
+                LocalisedText {
+                    en: "Melee",
+                    ja: "近接物理DPS",
+                    de: "Nahkampf-Angreifer",
+                    fr: "DPS de mêlée",
+                },
                 vec![
                     Self::MONK,
                     Self::DRAGOON,
@@ -600,11 +615,21 @@ impl JobFlags {
                 ],
             ),
             (
-                "Phys Ranged",
+                LocalisedText {
+                    en: "Physical Ranged",
+                    ja: "遠隔物理DPS",
+                    de: "Physischer Fernkampf-Angreifer",
+                    fr: "DPS physiques à distance",
+                },
                 vec![Self::BARD, Self::MACHINIST, Self::DANCER],
             ),
             (
-                "Magic Ranged",
+                LocalisedText {
+                    en: "Magical Ranged",
+                    ja: "遠隔魔法DPS",
+                    de: "Magischer Fernkampf-Angreifer",
+                    fr: "DPS magiques à distance",
+                },
                 vec![
                     Self::BLACK_MAGE,
                     Self::SUMMONER,

--- a/server/src/listing.rs
+++ b/server/src/listing.rs
@@ -215,26 +215,7 @@ pub struct PartyFinderSlot {
 
 impl PartyFinderSlot {
     pub fn html_classes(&self) -> String {
-        if self.accepting == JobFlags::all() {
-            return "empty".into();
-        }
-
-        let mut classes = Vec::with_capacity(3);
-        let cjs = self.accepting.classjobs();
-
-        if cjs.iter().any(|cj| cj.role() == Some(Role::Healer)) {
-            classes.push("healer");
-        }
-
-        if cjs.iter().any(|cj| cj.role() == Some(Role::Tank)) {
-            classes.push("tank");
-        }
-
-        if cjs.iter().any(|cj| cj.role() == Some(Role::Dps)) {
-            classes.push("dps");
-        }
-
-        classes.join(" ")
+        self.accepting.html_classes()
     }
 
     pub fn codes(&self) -> String {
@@ -562,6 +543,77 @@ impl JobFlags {
         }
 
         cjs
+    }
+
+    pub fn html_classes(&self) -> String {
+        if *self == JobFlags::all() {
+            return "empty".into();
+        }
+
+        let mut classes = Vec::with_capacity(3);
+        let cjs = self.classjobs();
+
+        if cjs.iter().any(|cj| cj.role() == Some(Role::Healer)) {
+            classes.push("healer");
+        }
+
+        if cjs.iter().any(|cj| cj.role() == Some(Role::Tank)) {
+            classes.push("tank");
+        }
+
+        if cjs.iter().any(|cj| cj.role() == Some(Role::Dps)) {
+            classes.push("dps");
+        }
+
+        classes.join(" ")
+    }
+
+    pub fn get_all_jobs() -> Vec<(&'static str, Vec<JobFlags>)> {
+        vec![
+            (
+                "Tanks",
+                vec![
+                    Self::PALADIN,
+                    Self::WARRIOR,
+                    Self::DARK_KNIGHT,
+                    Self::GUNBREAKER,
+                ],
+            ),
+            (
+                "Healers",
+                vec![
+                    Self::WHITE_MAGE,
+                    Self::SCHOLAR,
+                    Self::ASTROLOGIAN,
+                    Self::SAGE,
+                ],
+            ),
+            (
+                "Melees",
+                vec![
+                    Self::MONK,
+                    Self::DRAGOON,
+                    Self::NINJA,
+                    Self::SAMURAI,
+                    Self::REAPER,
+                    Self::VIPER,
+                ],
+            ),
+            (
+                "Phys Ranged",
+                vec![Self::BARD, Self::MACHINIST, Self::DANCER],
+            ),
+            (
+                "Magic Ranged",
+                vec![
+                    Self::BLACK_MAGE,
+                    Self::SUMMONER,
+                    Self::RED_MAGE,
+                    Self::PICTOMANCER,
+                    Self::BLUE_MAGE,
+                ],
+            ),
+        ]
     }
 }
 

--- a/server/src/template/listings.rs
+++ b/server/src/template/listings.rs
@@ -1,4 +1,5 @@
 use crate::ffxiv::Language;
+use crate::listing::JobFlags;
 use crate::listing::PartyFinderCategory;
 use crate::listing_container::QueriedListing;
 use crate::sestring_ext::SeStringExt;

--- a/server/templates/listings.html
+++ b/server/templates/listings.html
@@ -53,6 +53,24 @@ xivpf - listings
                             </select>
                         </label>
                     </div>
+                    <div class="roles" id="role-filter">
+                        {%- for (role, jobs) in JobFlags::get_all_jobs() %}
+                            <small>
+                                {{ role }}
+                            </small>
+                            <div>
+                                {%- for job in jobs %}
+                                {%- let code = job.classjobs()[0].code() %}
+                                    <input type="checkbox" id="{{ code }}" value="{{ job.bits() }}"></input>
+                                    <label for="{{ code }}" title="{{ code }}" class="{{ job.html_classes() }}">
+                                        <svg viewBox="0 0 32 32">
+                                            <use href="/assets/icons.svg#{{ code }}"></use>
+                                        </svg>
+                                    </label>
+                                {%- endfor %}
+                            </div>
+                        {%- endfor %}
+                    </div>
                 </div>
             </details>
         </div>

--- a/server/templates/listings.html
+++ b/server/templates/listings.html
@@ -56,7 +56,7 @@ xivpf - listings
                     <div class="roles" id="role-filter">
                         {%- for (role, jobs) in JobFlags::get_all_jobs() %}
                             <small>
-                                {{ role }}
+                                {{ role.text(lang) }}
                             </small>
                             <div>
                                 {%- for job in jobs %}

--- a/server/templates/listings.html
+++ b/server/templates/listings.html
@@ -86,7 +86,8 @@ xivpf - listings
           data-id="{{ listing.id }}"
           data-centre="{{ listing.data_centre_name().unwrap_or_default() }}"
           data-pf-category="{{ listing.html_pf_category() }}"
-          data-joinable-roles="{{ listing.joinable_roles() }}">
+          data-joinable-roles="{{ listing.joinable_roles() }}"
+          data-num-parties="{{ listing.num_parties }}">
 
             <div class="left">
                 {%- let duty_class %}

--- a/server/templates/listings.html
+++ b/server/templates/listings.html
@@ -67,7 +67,9 @@ xivpf - listings
           class="listing"
           data-id="{{ listing.id }}"
           data-centre="{{ listing.data_centre_name().unwrap_or_default() }}"
-          data-pf-category="{{ listing.html_pf_category() }}">
+          data-pf-category="{{ listing.html_pf_category() }}"
+          data-joinable-roles="{{ listing.joinable_roles() }}">
+
             <div class="left">
                 {%- let duty_class %}
                 {%- if listing.is_cross_world() %}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8ac947b-26f8-4153-9ec4-e8d1c9cd9457)

New to all this, especially Rust, so open to any suggestions. Tried my best to match existing code/style.

Implementation:
- For each listing, store all joinable roles/jobs using bitflags
- In the filter, each job has a checkbox that toggles their bitflag
- Then it is compared to the joinable roles to determine if the listing should be shown. Note that I had to use BigInt since javascript uses 32-bit signed integers for bitwise operations, which was resulting in negatives.

Missing:
- I only rendered the jobs to avoid clutter, but it shouldn't be too hard to add classes if we really want
- ~~Doesn't really work for alliance raids or pvp since we don't have accurate data for jobs present. Maybe I can have the filter ignore those.~~
  - ^ This is done. The filter only acts on listings with 1 party
- ~~Do we need translations?~~
- ~~Retain state between refreshes~~
- Tests